### PR TITLE
Fix typo in math cheatsheet

### DIFF
--- a/01_intro/01_02-02_data.ipynb
+++ b/01_intro/01_02-02_data.ipynb
@@ -755,8 +755,8 @@
     "| multiplication             | `*`  | multiplies two numbers              | `1*2`   |      2 |\n",
     "| exponential multiplication | `**` | performs exponential multiplication | `2**2`  |      4 |\n",
     "| division                   | `/`  | divides one number from another     | `2/2`   |      1 |\n",
-    "| modulo                     | `%`  | remainder                           | `2%7`   |      1 |\n",
-    "| floor                      | `//` | occurences                          | `2//7`  |      3 |\n",
+    "| modulo                     | `%`  | remainder                           | `22%7`  |      1 |\n",
+    "| floor                      | `//` | occurences                          | `22//7` |      3 |\n",
     "`````"
    ]
   },


### PR DESCRIPTION
The examples for % and // in the cheatsheet contain a typo, as the results shown in the table only make sense if you use 22 instead of 2.